### PR TITLE
Build: update Intellij Platform version to 242.20224

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
 
         pluginVerifier()
     }
+
+    testImplementation(libs.openTest4J)
 }
 
 intellijPlatform {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginRepositoryUrl = https://github.com/ForNeVeR/Todosaurus
 pluginVersion = 1.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-platformVersion=242.10180-EAP-CANDIDATE-SNAPSHOT
+platformVersion=242.20224-EAP-CANDIDATE-SNAPSHOT
 pluginUntilBuild=243.*
 
 # This is required to depend on preview IntelliJ artifacts from Maven rather than "binary" releases / installers.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,9 @@
 changelog = "2.2.1"
 qodana = "2024.1.5"
 
+[libraries]
+openTest4J = "org.opentest4j:opentest4j:1.3.0"
+
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 gradleIntelliJPlatformPlugin = "org.jetbrains.intellij.platform:2.0.0-beta5"


### PR DESCRIPTION
The currently used sandbox IntelliJ Platform (242.10180-EAP-CANDIDATE-SNAPSHOT) was affected by [a serious security issue](https://blog.jetbrains.com/security/2024/06/updates-for-security-issue-affecting-intellij-based-ides-2023-1-and-github-plugin/) which made it impossible to use the JetBrains GitHub Plugin. Creating an issue using the IntelliJ Platform of this version fails with `GithubAuthenticationException:  Access to this site has been restricted. If you believe this is an error, please contact https://support.github.com`. However, using the IntelliJ Platform of version 242.20224-EAP-CANDIDATE-SNAPSHOT resolves the problem.