### PR TITLE
(#21) Implement navigation to existing issue using browser

### DIFF
--- a/src/main/kotlin/me/fornever/todosaurus/actions/CreateIssueAction.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/actions/CreateIssueAction.kt
@@ -1,14 +1,10 @@
 package me.fornever.todosaurus.actions
 
-import com.intellij.ide.todo.TodoPanel
-import com.intellij.ide.todo.nodes.TodoItemNode
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.PlatformDataKeys
-import com.intellij.openapi.editor.RangeMarker
-import com.intellij.ui.treeStructure.Tree
-import com.intellij.util.ui.tree.TreeUtil
+import me.fornever.todosaurus.actions.extensions.getToDoTextRange
+import me.fornever.todosaurus.actions.extensions.tryActivateThisAction
 import me.fornever.todosaurus.services.ToDoItem
 import me.fornever.todosaurus.services.ToDoService
 
@@ -17,14 +13,8 @@ class CreateIssueAction : AnAction() {
     override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
-        val toDoPanel = e.getData(TodoPanel.TODO_PANEL_DATA_KEY)
-        val project = e.project
-        if (toDoPanel == null || project == null) {
-            e.presentation.isEnabledAndVisible = false
+        if (!e.tryActivateThisAction())
             return
-        }
-
-        e.presentation.isVisible = true
 
         val range = e.getToDoTextRange()
         e.presentation.isEnabled = range != null && ToDoItem(range).isNew
@@ -35,10 +25,4 @@ class CreateIssueAction : AnAction() {
         val range = e.getToDoTextRange() ?: return
         ToDoService.getInstance(project).showCreateIssueDialog(range)
     }
-}
-
-private fun AnActionEvent.getToDoTextRange(): RangeMarker? {
-    val tree = getData(PlatformDataKeys.CONTEXT_COMPONENT) as? Tree
-    val descriptor = tree?.selectionPath?.let(TreeUtil::getLastUserObject) as? TodoItemNode
-    return descriptor?.value?.rangeMarker
 }

--- a/src/main/kotlin/me/fornever/todosaurus/actions/OpenIssueAfterCreationAction.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/actions/OpenIssueAfterCreationAction.kt
@@ -1,0 +1,18 @@
+package me.fornever.todosaurus.actions
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import me.fornever.todosaurus.TodosaurusBundle
+import org.jetbrains.plugins.github.api.data.GithubIssue
+
+class OpenIssueAfterCreationAction(private val issue: GithubIssue) : AnAction(
+    TodosaurusBundle.message("notification.issueCreated.openIssue")
+) {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val url = issue.htmlUrl
+        BrowserUtil.browse(url, project)
+    }
+}

--- a/src/main/kotlin/me/fornever/todosaurus/actions/OpenIssueInBrowserAction.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/actions/OpenIssueInBrowserAction.kt
@@ -3,16 +3,15 @@ package me.fornever.todosaurus.actions
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import kotlinx.coroutines.*
-import me.fornever.todosaurus.TodosaurusBundle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import me.fornever.todosaurus.actions.extensions.getToDoTextRange
 import me.fornever.todosaurus.actions.extensions.tryActivateThisAction
 import me.fornever.todosaurus.services.ToDoItem
 import me.fornever.todosaurus.services.ToDoService
 
-class OpenIssueInBrowserAction : AnAction(
-    TodosaurusBundle.message("notification.openIssueInBrowser.action.name")
-) {
+class OpenIssueInBrowserAction : AnAction() {
     override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {

--- a/src/main/kotlin/me/fornever/todosaurus/actions/OpenIssueInBrowserAction.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/actions/OpenIssueInBrowserAction.kt
@@ -1,0 +1,35 @@
+package me.fornever.todosaurus.actions
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import kotlinx.coroutines.*
+import me.fornever.todosaurus.TodosaurusBundle
+import me.fornever.todosaurus.actions.extensions.getToDoTextRange
+import me.fornever.todosaurus.actions.extensions.tryActivateThisAction
+import me.fornever.todosaurus.services.ToDoItem
+import me.fornever.todosaurus.services.ToDoService
+
+class OpenIssueInBrowserAction : AnAction(
+    TodosaurusBundle.message("notification.openIssueInBrowser.action.name")
+) {
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        if (!e.tryActivateThisAction())
+            return
+
+        val range = e.getToDoTextRange()
+        e.presentation.isEnabled = range != null && ToDoItem(range).issueNumber != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val range = e.getToDoTextRange() ?: return
+        val toDoService = ToDoService.getInstance(project)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            toDoService.openIssueInBrowser(range)
+        }
+    }
+}

--- a/src/main/kotlin/me/fornever/todosaurus/actions/extensions/AnActionEventExtensions.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/actions/extensions/AnActionEventExtensions.kt
@@ -1,0 +1,30 @@
+package me.fornever.todosaurus.actions.extensions
+
+import com.intellij.ide.todo.TodoPanel
+import com.intellij.ide.todo.nodes.TodoItemNode
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.ui.tree.TreeUtil
+
+fun AnActionEvent.getToDoTextRange(): RangeMarker? {
+    val tree = getData(PlatformDataKeys.CONTEXT_COMPONENT) as? Tree
+    val descriptor = tree?.selectionPath?.let(TreeUtil::getLastUserObject) as? TodoItemNode
+    return descriptor?.value?.rangeMarker
+}
+
+fun AnActionEvent.tryActivateThisAction(): Boolean {
+    val toDoPanel = getData(TodoPanel.TODO_PANEL_DATA_KEY)
+    val project = project
+
+    if (toDoPanel == null || project == null) {
+        presentation.isEnabledAndVisible = false
+
+        return false
+    }
+
+    presentation.isVisible = true
+
+    return true
+}

--- a/src/main/kotlin/me/fornever/todosaurus/actions/extensions/AnActionEventExtensions.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/actions/extensions/AnActionEventExtensions.kt
@@ -16,7 +16,6 @@ fun AnActionEvent.getToDoTextRange(): RangeMarker? {
 
 fun AnActionEvent.tryActivateThisAction(): Boolean {
     val toDoPanel = getData(TodoPanel.TODO_PANEL_DATA_KEY)
-    val project = project
 
     if (toDoPanel == null || project == null) {
         presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/me/fornever/todosaurus/models/GetIssueModel.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/models/GetIssueModel.kt
@@ -1,0 +1,10 @@
+package me.fornever.todosaurus.models
+
+import me.fornever.todosaurus.services.ToDoItem
+import org.jetbrains.plugins.github.authentication.accounts.GithubAccount
+
+data class GetIssueModel(
+	val repository: RepositoryModel?,
+    val account: GithubAccount?,
+	val toDoItem: ToDoItem
+)

--- a/src/main/kotlin/me/fornever/todosaurus/models/GetIssueModel.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/models/GetIssueModel.kt
@@ -1,10 +1,9 @@
 package me.fornever.todosaurus.models
 
-import me.fornever.todosaurus.services.ToDoItem
 import org.jetbrains.plugins.github.authentication.accounts.GithubAccount
 
 data class GetIssueModel(
 	val repository: RepositoryModel?,
     val account: GithubAccount?,
-	val toDoItem: ToDoItem
+	val issueNumber: Long
 )

--- a/src/main/kotlin/me/fornever/todosaurus/services/GitHubService.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/services/GitHubService.kt
@@ -34,7 +34,7 @@ class GitHubService(private val project: Project) {
     suspend fun getIssue(model: GetIssueModel): GithubIssue? {
         val repository = model.repository ?: error("Repository for this project not found.")
         val issueNumber = readAction {
-            model.toDoItem.issueNumber?.toString() ?: error("Issue number must be specified.")
+            model.issueNumber.toString()
         }
 
         val executorFactory = GithubApiRequestExecutor.Factory.getInstance()

--- a/src/main/kotlin/me/fornever/todosaurus/services/ToDoItem.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/services/ToDoItem.kt
@@ -1,6 +1,7 @@
 package me.fornever.todosaurus.services
 
 import com.intellij.openapi.editor.RangeMarker
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import com.intellij.util.concurrency.annotations.RequiresWriteLock
 
 class ToDoItem(val range: RangeMarker) {
@@ -31,6 +32,21 @@ class ToDoItem(val range: RangeMarker) {
     val description: String
         get() = (if (text.contains("\n")) text.substringAfter('\n') + "\n" else "") +
             issueDescriptionTemplate
+
+    @get:RequiresReadLock
+    val issueNumber: Long?
+        get() {
+            if (isNew)
+                return null
+
+            val number = text
+                .substringAfter("[")
+                .substringBefore("]")
+                .replace("#", "")
+                .takeIf { it.all { symbol -> symbol.isDigit() } }
+
+            return number?.toLongOrNull()
+        }
 
     @RequiresWriteLock
     fun markAsReported(issueNumber: Long) {

--- a/src/main/kotlin/me/fornever/todosaurus/views/CreateIssueDialog.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/views/CreateIssueDialog.kt
@@ -94,7 +94,7 @@ class CreateIssueDialog(
                 isInProgress = true
                 try {
                     val newIssue = GitHubService.getInstance(project).createIssue(model)
-                    Notifications.issueCreated(newIssue, project)
+                    Notifications.CreateIssue.success(newIssue, project)
                     ToDoService.getInstance(project).updateDocumentText(model.toDoItem, newIssue)
                     withUiContext {
                         doOKAction()

--- a/src/main/kotlin/me/fornever/todosaurus/views/Notifications.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/views/Notifications.kt
@@ -1,32 +1,31 @@
 package me.fornever.todosaurus.views
 
-import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import me.fornever.todosaurus.TodosaurusBundle
+import me.fornever.todosaurus.actions.OpenIssueAfterCreationAction
 import org.jetbrains.plugins.github.api.data.GithubIssue
 
 object Notifications {
-    fun issueCreated(issue: GithubIssue, project: Project) {
-        val text = TodosaurusBundle.message("notification.issueCreated.text", issue.number)
-        NotificationGroupManager.getInstance()
-            .getNotificationGroup("TodosaurusNotifications")
-            .createNotification(text, NotificationType.INFORMATION)
-            .addAction(OpenIssueAction(issue))
-            .notify(project)
+    object CreateIssue {
+        fun success(issue: GithubIssue, project: Project) {
+            val text = TodosaurusBundle.message("notification.issueCreated.text", issue.number)
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("TodosaurusNotifications")
+                .createNotification(text, NotificationType.INFORMATION)
+                .addAction(OpenIssueAfterCreationAction(issue))
+                .notify(project)
+        }
     }
-}
 
-private class OpenIssueAction(private val issue: GithubIssue) : AnAction(
-    TodosaurusBundle.message("notification.issueCreated.openIssue")
-) {
-
-    override fun actionPerformed(e: AnActionEvent) {
-        val project = e.project ?: return
-        val url = issue.htmlUrl
-        BrowserUtil.browse(url, project)
+    object OpenIssueInBrowser {
+        fun failed(exception: Exception, project: Project) {
+            val title = TodosaurusBundle.message("notification.openIssueInBrowser.fail.title")
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("TodosaurusNotifications")
+                .createNotification(title, exception.message ?: "Unexpected error", NotificationType.ERROR)
+                .notify(project)
+        }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,9 @@
         <action id="CreateIssue" class="me.fornever.todosaurus.actions.CreateIssueAction">
             <add-to-group group-id="VersionControlsGroup" /> <!-- TODO[#18]: This is a temporary solution until the TODO tool window supports a proper action group -->
         </action>
+        <action id="OpenIssueInBrowser" class="me.fornever.todosaurus.actions.OpenIssueInBrowserAction">
+            <add-to-group group-id="VersionControlsGroup" /> <!-- TODO[#18]: This is a temporary solution until the TODO tool window supports a proper action group -->
+        </action>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/main/resources/messages/TodosaurusBundle.properties
+++ b/src/main/resources/messages/TodosaurusBundle.properties
@@ -1,4 +1,5 @@
 action.CreateIssue.text=Create Issue
+action.OpenIssueInBrowser.text=Open Issue in Browser
 
 command.update.todo.item=Update TODO Item
 
@@ -12,5 +13,4 @@ createIssueDialog.title=Create Issue
 notification.group.name=Todosaurus
 notification.issueCreated.openIssue=Open in Browser
 notification.issueCreated.text=Issue {0} has been created.
-notification.openIssueInBrowser.action.name=Open Issue in Browser
 notification.openIssueInBrowser.fail.title=Failed to open issue in browser

--- a/src/main/resources/messages/TodosaurusBundle.properties
+++ b/src/main/resources/messages/TodosaurusBundle.properties
@@ -12,5 +12,5 @@ createIssueDialog.title=Create Issue
 notification.group.name=Todosaurus
 notification.issueCreated.openIssue=Open in Browser
 notification.issueCreated.text=Issue {0} has been created.
-notification.openIssueInBrowser.action.name=Open in Browser
+notification.openIssueInBrowser.action.name=Open Issue in Browser
 notification.openIssueInBrowser.fail.title=Failed to open issue in browser

--- a/src/main/resources/messages/TodosaurusBundle.properties
+++ b/src/main/resources/messages/TodosaurusBundle.properties
@@ -12,3 +12,5 @@ createIssueDialog.title=Create Issue
 notification.group.name=Todosaurus
 notification.issueCreated.openIssue=Open in Browser
 notification.issueCreated.text=Issue {0} has been created.
+notification.openIssueInBrowser.action.name=Open in Browser
+notification.openIssueInBrowser.fail.title=Failed to open issue in browser

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IsReportedTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IsReportedTests.kt
@@ -9,7 +9,7 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 @RunWith(Parameterized::class)
-class IsReadyTests(private val readyItem: String) {
+class IsReportedTests(private val readyItem: String) {
     companion object {
         @JvmStatic
         @Parameters
@@ -20,7 +20,7 @@ class IsReadyTests(private val readyItem: String) {
     }
 
     @Test
-    fun `ToDo item should be ready`() {
+    fun `ToDo item should be reported`() {
         // Arrange
         val sut = ToDoItem(FakeRangeMarker(readyItem))
 

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IssueNumberTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IssueNumberTests.kt
@@ -1,0 +1,54 @@
+package me.fornever.todosaurus.toDoItemTests
+
+import me.fornever.todosaurus.services.ToDoItem
+import me.fornever.todosaurus.testFramework.FakeRangeMarker
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+class IssueNumberTests(private val source: String, private val expected: Long?) {
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun newItems()
+            = arrayOf(
+                arrayOf("TODO[#111]:", 111L),
+                arrayOf("todo[#112]:", 112L),
+                arrayOf("text Todo[#113]:", 113L),
+                arrayOf("ToDo[#114]:", 114L),
+                arrayOf("Todo[#115]:text", 115L),
+                arrayOf("ToDo[#116]: Text", 116L),
+                arrayOf("Todo[#117]:Text", 117L),
+                arrayOf("TODO[#118]:    Text", 118L),
+                arrayOf("TODO", null),
+                arrayOf("todo", null),
+                arrayOf("text Todo", null),
+                arrayOf("ToDo 119", null),
+                arrayOf("Todo[120]:text", 120L),
+                arrayOf("ToDo[#121]: Text", 121L),
+                arrayOf("Todo[#122]:Text", 122L),
+                arrayOf("TODO[#123]:    Text", 123L),
+                arrayOf("TODO [124]", null),
+                arrayOf("todo [125]", null),
+                arrayOf("text Todo [#126]", null),
+                arrayOf("ToDo[a127]:", null),
+                arrayOf("Todo[c128b]:text", null),
+                arrayOf("ToDo[129d]: Text", null),
+                arrayOf("ToDo[1a30]:", null),
+                arrayOf("Todo[13c1]:text", null),
+                arrayOf("ToDo[1b3c2]: Text", null)
+            )
+    }
+
+    @Test
+    fun `Should returns issue number properly`() {
+        // Arrange
+        val sut = ToDoItem(FakeRangeMarker(source))
+
+        // Act & Assert
+        Assert.assertEquals(expected, sut.issueNumber)
+    }
+}

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/MarkAsReportedTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/MarkAsReportedTests.kt
@@ -10,7 +10,7 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 @RunWith(Parameterized::class)
-class MarkAsReadyTests(private val newItem: String) {
+class MarkAsReportedTests(private val newItem: String) {
     companion object {
         @JvmStatic
         @Parameters
@@ -27,7 +27,7 @@ class MarkAsReadyTests(private val newItem: String) {
     }
 
     @Test
-    fun `Should mark ToDo item as ready`() {
+    fun `Should mark ToDo item as reported`() {
         // Arrange
         val expected = "TODO[#1]:"
         val sut = ToDoItem(FakeRangeMarker(newItem))


### PR DESCRIPTION
Closes #21 

### Added
- Added parsing of issue number in `ToDoItem` (+ this property covered by tests)
- Added new `Open in Browser` action for `TODO` panel

  ![image](https://github.com/user-attachments/assets/94ab799a-5e9b-495d-ad0d-219080821cb9)

  If an error occurs while performing this action, a notification will be displayed

  ![image](https://github.com/user-attachments/assets/d3b38d38-2aba-4a69-9c84-aad432266773)

### Changed
- Some minor stuff has been refactored

### Known issues
It's not very clear how to get the account and repository to generate the link. We can probably solve this by implementing https://github.com/ForNeVeR/Todosaurus/issues/38