### PR TITLE
(#133) Allow ToDoItem to accept Todosaurus settings externally

### DIFF
--- a/src/main/kotlin/me/fornever/todosaurus/issues/ToDoItem.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/issues/ToDoItem.kt
@@ -4,20 +4,16 @@
 
 package me.fornever.todosaurus.issues
 
-import com.intellij.openapi.components.serviceOrNull
 import com.intellij.openapi.editor.RangeMarker
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import com.intellij.util.concurrency.annotations.RequiresWriteLock
 import me.fornever.todosaurus.settings.TodosaurusSettings
 
-class ToDoItem(val toDoRange: RangeMarker) {
+class ToDoItem(private val settings: TodosaurusSettings.State, val toDoRange: RangeMarker) {
     private companion object {
         val newItemPattern: Regex
             = Regex("\\b(?i)TODO(?-i)\\b:?(?!\\[.*?])") // https://regex101.com/r/lDDqm7/2
     }
-
-    private val settings = serviceOrNull<TodosaurusSettings>()?.state
-        ?: TodosaurusSettings.State.defaultState // TODO[#133]: Tests broke if we replaced serviceOrNull with TodosaurusSettings.getInstance
 
     private val text: String
         get() = toDoRange

--- a/src/main/kotlin/me/fornever/todosaurus/ui/actions/CreateNewIssueAction.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/ui/actions/CreateNewIssueAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import me.fornever.todosaurus.issues.ToDoItem
 import me.fornever.todosaurus.issues.ToDoService
+import me.fornever.todosaurus.settings.TodosaurusSettings
 
 class CreateNewIssueAction: AnAction() {
     override fun getActionUpdateThread() = ActionUpdateThread.BGT
@@ -18,12 +19,14 @@ class CreateNewIssueAction: AnAction() {
             return
 
         val toDoRange = actionEvent.getToDoTextRange()
-        actionEvent.presentation.isEnabled = toDoRange != null && ToDoItem(toDoRange).isNew
+        val todosaurusSettings = TodosaurusSettings.getInstance()
+        actionEvent.presentation.isEnabled = toDoRange != null && ToDoItem(todosaurusSettings.state, toDoRange).isNew
     }
 
     override fun actionPerformed(actionEvent: AnActionEvent) {
         val project = actionEvent.project ?: return
         val toDoRange = actionEvent.getToDoTextRange() ?: return
-        ToDoService.getInstance(project).createNewIssue(ToDoItem(toDoRange))
+        val todosaurusSettings = TodosaurusSettings.getInstance()
+        ToDoService.getInstance(project).createNewIssue(ToDoItem(todosaurusSettings.state, toDoRange))
     }
 }

--- a/src/main/kotlin/me/fornever/todosaurus/ui/actions/OpenReportedIssueInBrowserAction.kt
+++ b/src/main/kotlin/me/fornever/todosaurus/ui/actions/OpenReportedIssueInBrowserAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import me.fornever.todosaurus.issues.ToDoItem
 import me.fornever.todosaurus.issues.ToDoService
+import me.fornever.todosaurus.settings.TodosaurusSettings
 
 class OpenReportedIssueInBrowserAction : AnAction() {
     override fun getActionUpdateThread() = ActionUpdateThread.BGT
@@ -18,13 +19,14 @@ class OpenReportedIssueInBrowserAction : AnAction() {
             return
 
         val toDoRange = actionEvent.getToDoTextRange()
-        actionEvent.presentation.isEnabled = toDoRange != null && !ToDoItem(toDoRange).isNew
+        val todosaurusSettings = TodosaurusSettings.getInstance()
+        actionEvent.presentation.isEnabled = toDoRange != null && !ToDoItem(todosaurusSettings.state, toDoRange).isNew
     }
 
     override fun actionPerformed(actionEvent: AnActionEvent) {
         val project = actionEvent.project ?: return
         val toDoRange = actionEvent.getToDoTextRange() ?: return
-
-        ToDoService.getInstance(project).openReportedIssueInBrowser(ToDoItem(toDoRange))
+        val todosaurusSettings = TodosaurusSettings.getInstance()
+        ToDoService.getInstance(project).openReportedIssueInBrowser(ToDoItem(todosaurusSettings.state, toDoRange))
     }
 }

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IsNewTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IsNewTests.kt
@@ -5,6 +5,7 @@
 package me.fornever.todosaurus.toDoItemTests
 
 import me.fornever.todosaurus.issues.ToDoItem
+import me.fornever.todosaurus.settings.TodosaurusSettings
 import me.fornever.todosaurus.testFramework.FakeRangeMarker
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -32,7 +33,7 @@ class IsNewTests(private val newItem: String) {
     @Test
     fun `ToDo item should be new`() {
         // Arrange
-        val sut = ToDoItem(FakeRangeMarker(newItem))
+        val sut = ToDoItem(TodosaurusSettings.State.defaultState, FakeRangeMarker(newItem))
 
         // Act & Assert
         assertTrue(sut.isNew)

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IsReportedTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IsReportedTests.kt
@@ -5,6 +5,7 @@
 package me.fornever.todosaurus.toDoItemTests
 
 import me.fornever.todosaurus.issues.ToDoItem
+import me.fornever.todosaurus.settings.TodosaurusSettings
 import me.fornever.todosaurus.testFramework.FakeRangeMarker
 import org.junit.Assert
 import org.junit.Test
@@ -26,7 +27,7 @@ class IsReportedTests(private val readyItem: String) {
     @Test
     fun `ToDo item should be reported`() {
         // Arrange
-        val sut = ToDoItem(FakeRangeMarker(readyItem))
+        val sut = ToDoItem(TodosaurusSettings.State.defaultState, FakeRangeMarker(readyItem))
 
         // Act & Assert
 		Assert.assertFalse(sut.isNew)

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IssueNumberTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/IssueNumberTests.kt
@@ -5,6 +5,7 @@
 package me.fornever.todosaurus.toDoItemTests
 
 import me.fornever.todosaurus.issues.ToDoItem
+import me.fornever.todosaurus.settings.TodosaurusSettings
 import me.fornever.todosaurus.testFramework.FakeRangeMarker
 import org.junit.Assert
 import org.junit.Test
@@ -50,7 +51,7 @@ class IssueNumberTests(private val source: String, private val expected: String?
     @Test
     fun `Should returns issue number properly`() {
         // Arrange
-        val sut = ToDoItem(FakeRangeMarker(source))
+        val sut = ToDoItem(TodosaurusSettings.State.defaultState, FakeRangeMarker(source))
 
         // Act & Assert
         Assert.assertEquals(expected, sut.issueNumber)

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/MarkAsReportedTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/MarkAsReportedTests.kt
@@ -5,6 +5,7 @@
 package me.fornever.todosaurus.toDoItemTests
 
 import me.fornever.todosaurus.issues.ToDoItem
+import me.fornever.todosaurus.settings.TodosaurusSettings
 import me.fornever.todosaurus.testFramework.FakeRangeMarker
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -34,7 +35,7 @@ class MarkAsReportedTests(private val newItem: String) {
     fun `Should mark ToDo item as reported`() {
         // Arrange
         val expected = "TODO[#1]:"
-        val sut = ToDoItem(FakeRangeMarker(newItem))
+        val sut = ToDoItem(TodosaurusSettings.State.defaultState, FakeRangeMarker(newItem))
 
         // Act
         sut.markAsReported("1")
@@ -46,7 +47,7 @@ class MarkAsReportedTests(private val newItem: String) {
     @Test
     fun `ToDo item should not be new`() {
         // Arrange
-        val sut = ToDoItem(FakeRangeMarker(newItem))
+        val sut = ToDoItem(TodosaurusSettings.State.defaultState, FakeRangeMarker(newItem))
 
         // Act
         sut.markAsReported("1")

--- a/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/TitleTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/toDoItemTests/TitleTests.kt
@@ -5,6 +5,7 @@
 package me.fornever.todosaurus.toDoItemTests
 
 import me.fornever.todosaurus.issues.ToDoItem
+import me.fornever.todosaurus.settings.TodosaurusSettings
 import me.fornever.todosaurus.testFramework.FakeRangeMarker
 import org.junit.Assert
 import org.junit.Test
@@ -32,7 +33,7 @@ class TitleTests(private val source: String, private val expected: String) {
     @Test
     fun `Should calculate title properly`() {
         // Arrange
-        val sut = ToDoItem(FakeRangeMarker(source))
+        val sut = ToDoItem(TodosaurusSettings.State.defaultState, FakeRangeMarker(source))
 
         // Act & Assert
         Assert.assertEquals(expected, sut.title)

--- a/src/test/kotlin/me/fornever/todosaurus/wizardTests/TodosaurusWizardBuilderTests.kt
+++ b/src/test/kotlin/me/fornever/todosaurus/wizardTests/TodosaurusWizardBuilderTests.kt
@@ -7,6 +7,7 @@ package me.fornever.todosaurus.wizardTests
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import me.fornever.todosaurus.issues.ToDoItem
+import me.fornever.todosaurus.settings.TodosaurusSettings
 import me.fornever.todosaurus.testFramework.FakeProject
 import me.fornever.todosaurus.testFramework.FakeRangeMarker
 import me.fornever.todosaurus.ui.wizard.TodosaurusWizardBuilder
@@ -18,7 +19,7 @@ class TodosaurusWizardBuilderTests {
     @Test
     fun `Should link steps properly`() {
         // Arrange
-        val model = TodosaurusWizardContext(ToDoItem(FakeRangeMarker("TODO")))
+        val model = TodosaurusWizardContext(ToDoItem(TodosaurusSettings.State.defaultState, FakeRangeMarker("TODO")))
         val sut = TodosaurusWizardBuilder(FakeProject(), model, CoroutineScope(Dispatchers.IO))
         val firstStep = FakeWizardStep("1")
         val secondStep = FakeWizardStep("2")


### PR DESCRIPTION
Makes `ToDoItem` independent of dependency injection via `service<>()`. Useful for overriding settings in tests.

Will close #133.