### PR TITLE
`ToDoService`: get rid of the type checks

### DIFF
--- a/core/src/main/kotlin/me/fornever/todosaurus/core/git/ui/wizard/ChooseGitHostingRemoteStep.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/git/ui/wizard/ChooseGitHostingRemoteStep.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2025 Todosaurus contributors <https://github.com/ForNeVeR/Todosaurus>
+// SPDX-FileCopyrightText: 2024-2025 Todosaurus contributors <https://github.com/ForNeVeR/Todosaurus>
 //
 // SPDX-License-Identifier: MIT
 
@@ -21,7 +21,7 @@ import me.fornever.todosaurus.core.ui.wizard.TodosaurusWizardStep
 import me.fornever.todosaurus.core.ui.wizard.memoization.MemorableStep
 import javax.swing.JComponent
 
-class ChooseGitHostingRemoteStep(private val project: Project, private val model: TodosaurusWizardContext) : TodosaurusWizardStep(),
+class ChooseGitHostingRemoteStep(private val project: Project, private val model: TodosaurusWizardContext<*>) : TodosaurusWizardStep(),
     MemorableStep {
 
     override val id: String = ChooseGitHostingRemoteStep::class.java.name

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/issueTrackers/IssueTracker.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/issueTrackers/IssueTracker.kt
@@ -23,5 +23,5 @@ interface IssueTracker {
 
     fun createCredentialsProvider(project: Project): IssueTrackerCredentialsProvider
 
-    fun createChooseRemoteStep(project: Project, context: TodosaurusWizardContext): TodosaurusWizardStep
+    fun createChooseRemoteStep(project: Project, context: TodosaurusWizardContext<*>): TodosaurusWizardStep
 }

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/issueTrackers/ui/wizard/ChooseIssueTrackerStep.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/issueTrackers/ui/wizard/ChooseIssueTrackerStep.kt
@@ -37,7 +37,7 @@ import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.JLabel
 
-class ChooseIssueTrackerStep(private val project: Project, private val scope: CoroutineScope, private val model: TodosaurusWizardContext)
+class ChooseIssueTrackerStep(private val project: Project, private val scope: CoroutineScope, private val model: TodosaurusWizardContext<*>)
     : TodosaurusWizardStep(), DynamicStepProvider, MemorableStep {
 
     override val id: String = ChooseIssueTrackerStep::class.java.name

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/issues/ToDoService.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/issues/ToDoService.kt
@@ -33,7 +33,7 @@ class ToDoService(private val project: Project, private val scope: CoroutineScop
         fun getInstance(project: Project): ToDoService = project.service()
     }
 
-    fun createNewIssue(toDoItem: ToDoItem)
+    fun createNewIssue(toDoItem: ToDoItem.New)
         = scope.launch(Dispatchers.IO) {
             val savedChoice = UserChoiceStore
                 .getInstance(project)
@@ -67,11 +67,8 @@ class ToDoService(private val project: Project, private val scope: CoroutineScop
             }
         }
 
-    private suspend fun createNewIssue(model: TodosaurusWizardContext): WizardResult {
+    private suspend fun createNewIssue(model: TodosaurusWizardContext<ToDoItem.New>): WizardResult {
         try {
-            if (model.toDoItem !is ToDoItem.New)
-                error("TODO must be new in order to create an issue")
-
             val issueTracker = model.connectionDetails.issueTracker
                 ?: error("Issue tracker must be specified")
 
@@ -103,7 +100,7 @@ class ToDoService(private val project: Project, private val scope: CoroutineScop
         }
     }
 
-    fun openReportedIssueInBrowser(toDoItem: ToDoItem)
+    fun openReportedIssueInBrowser(toDoItem: ToDoItem.Reported)
         = scope.launch(Dispatchers.IO) {
             val savedChoice = UserChoiceStore
                 .getInstance(project)
@@ -129,11 +126,8 @@ class ToDoService(private val project: Project, private val scope: CoroutineScop
             }
         }
 
-    private suspend fun openReportedIssueInBrowser(model: TodosaurusWizardContext): WizardResult {
+    private suspend fun openReportedIssueInBrowser(model: TodosaurusWizardContext<ToDoItem.Reported>): WizardResult {
         try {
-            if (model.toDoItem !is ToDoItem.Reported)
-                error("TODO must be reported in order to open issue in browser")
-
             val issueTracker = model.connectionDetails.issueTracker
                 ?: error("Issue tracker must be specified")
 
@@ -161,7 +155,7 @@ class ToDoService(private val project: Project, private val scope: CoroutineScop
         }
     }
 
-    private suspend fun retrieveWizardContextBasedOnUserChoice(toDoItem: ToDoItem, userChoice: UserChoice): TodosaurusWizardContext {
+    private suspend fun <T : ToDoItem> retrieveWizardContextBasedOnUserChoice(toDoItem: T, userChoice: UserChoice): TodosaurusWizardContext<T> {
         val issueTrackerId = userChoice.issueTrackerId
             ?: error("Issue tracker id must be specified")
 

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/issues/ui/wizard/CreateNewIssueStep.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/issues/ui/wizard/CreateNewIssueStep.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.*
 import me.fornever.todosaurus.core.TodosaurusCoreBundle
+import me.fornever.todosaurus.core.issues.ToDoItem
 import me.fornever.todosaurus.core.issues.ToDoService
 import me.fornever.todosaurus.core.ui.wizard.TodosaurusWizardContext
 import me.fornever.todosaurus.core.ui.wizard.TodosaurusWizardStep
@@ -15,7 +16,7 @@ import me.fornever.todosaurus.core.ui.wizard.memoization.ForgettableStep
 import me.fornever.todosaurus.core.ui.wizard.memoization.UserChoiceStore
 import javax.swing.JComponent
 
-class CreateNewIssueStep(private val project: Project, private val model: TodosaurusWizardContext) : TodosaurusWizardStep(), ForgettableStep {
+class CreateNewIssueStep(private val project: Project, private val model: TodosaurusWizardContext<ToDoItem.New>) : TodosaurusWizardStep(), ForgettableStep {
 
     override val id: String = CreateNewIssueStep::class.java.name
 

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/ui/actions/CreateNewIssueAction.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/ui/actions/CreateNewIssueAction.kt
@@ -27,6 +27,6 @@ class CreateNewIssueAction: AnAction() {
         val project = actionEvent.project ?: return
         val toDoRange = actionEvent.getToDoTextRange() ?: return
         val todosaurusSettings = TodosaurusSettings.getInstance()
-        ToDoService.getInstance(project).createNewIssue(ToDoItem.fromRange(toDoRange, todosaurusSettings.state))
+        ToDoService.getInstance(project).createNewIssue(ToDoItem.fromRange(toDoRange, todosaurusSettings.state) as ToDoItem.New)
     }
 }

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/ui/actions/OpenReportedIssueInBrowserAction.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/ui/actions/OpenReportedIssueInBrowserAction.kt
@@ -27,6 +27,6 @@ class OpenReportedIssueInBrowserAction : AnAction() {
         val project = actionEvent.project ?: return
         val toDoRange = actionEvent.getToDoTextRange() ?: return
         val todosaurusSettings = TodosaurusSettings.getInstance()
-        ToDoService.getInstance(project).openReportedIssueInBrowser(ToDoItem.fromRange(toDoRange, todosaurusSettings.state))
+        ToDoService.getInstance(project).openReportedIssueInBrowser(ToDoItem.fromRange(toDoRange, todosaurusSettings.state) as ToDoItem.Reported)
     }
 }

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/ui/wizard/TodosaurusWizard.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/ui/wizard/TodosaurusWizard.kt
@@ -47,7 +47,7 @@ class TodosaurusWizard(
     title: String,
     private val project: Project,
     private val scope: CoroutineScope,
-    private val model: TodosaurusWizardContext,
+    private val model: TodosaurusWizardContext<*>,
     private val finalAction: suspend () -> WizardResult)
     : AbstractWizard<TodosaurusWizardStep>(title, project) {
 

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/ui/wizard/TodosaurusWizardBuilder.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/ui/wizard/TodosaurusWizardBuilder.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2025 Todosaurus contributors <https://github.com/ForNeVeR/Todosaurus>
+// SPDX-FileCopyrightText: 2024-2025 Todosaurus contributors <https://github.com/ForNeVeR/Todosaurus>
 //
 // SPDX-License-Identifier: MIT
 
@@ -7,7 +7,11 @@ package me.fornever.todosaurus.core.ui.wizard
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CoroutineScope
 
-class TodosaurusWizardBuilder(private val project: Project, private val model: TodosaurusWizardContext, private val scope: CoroutineScope) {
+class TodosaurusWizardBuilder(
+    private val project: Project,
+    private val model: TodosaurusWizardContext<*>,
+    private val scope: CoroutineScope
+) {
     private var wizardTitle: String? = null
     private var finalButtonName: String? = null
     private var finalAction: (suspend () -> WizardResult)? = null

--- a/core/src/main/kotlin/me/fornever/todosaurus/core/ui/wizard/TodosaurusWizardContext.kt
+++ b/core/src/main/kotlin/me/fornever/todosaurus/core/ui/wizard/TodosaurusWizardContext.kt
@@ -8,8 +8,8 @@ import me.fornever.todosaurus.core.issueTrackers.IssueTrackerConnectionDetails
 import me.fornever.todosaurus.core.issues.IssuePlacementDetails
 import me.fornever.todosaurus.core.issues.ToDoItem
 
-data class TodosaurusWizardContext(
-    val toDoItem: ToDoItem,
+data class TodosaurusWizardContext<TItem : ToDoItem>(
+    val toDoItem: TItem,
     val connectionDetails: IssueTrackerConnectionDetails = IssueTrackerConnectionDetails(),
     var placementDetails: IssuePlacementDetails? = null
 )

--- a/github/src/main/kotlin/me/fornever/todosaurus/gitHub/GitHub.kt
+++ b/github/src/main/kotlin/me/fornever/todosaurus/gitHub/GitHub.kt
@@ -67,7 +67,7 @@ class GitHub(override val icon: Icon, override val title: String) : IssueTracker
 
     override fun createChooseRemoteStep(
         project: Project,
-        context: TodosaurusWizardContext
+        context: TodosaurusWizardContext<*>
     ) = ChooseGitHostingRemoteStep(project, context)
 
     override fun createCredentialsProvider(project: Project) = GitHubCredentialsProvider(project)


### PR DESCRIPTION
Different methods of `ToDoService` now accept different variants of `ToDoItem` → almost no type checks anywhere (except for type casts in actions that have already checked the item types in their `update` methods).

`TodosaurusWizardContext` now knows the type of the underlying model.