### PR TITLE
Modules: fix dependencies

### DIFF
--- a/core/src/main/resources/me.fornever.todosaurus.core.xml
+++ b/core/src/main/resources/me.fornever.todosaurus.core.xml
@@ -7,6 +7,7 @@
 <idea-plugin package="me.fornever.todosaurus.core">
 
     <dependencies>
+        <plugin id="Git4Idea"/>
         <plugin id="com.intellij.tasks"/>
     </dependencies>
 

--- a/gitLab/src/main/resources/me.fornever.todosaurus.gitLab.xml
+++ b/gitLab/src/main/resources/me.fornever.todosaurus.gitLab.xml
@@ -7,6 +7,7 @@
 <idea-plugin package="me.fornever.todosaurus.gitLab">
     <dependencies>
         <module name="me.fornever.todosaurus.core"/>
+        <plugin id="com.intellij.tasks"/>
         <plugin id="org.jetbrains.plugins.gitlab"/>
     </dependencies>
 


### PR DESCRIPTION
Any compile-time dependency must correspond to the runtime dependencies.

Closes #171.