### PR TITLE
Improve wizard UI: show selected issue tracker details and action link [#173]

### DIFF
--- a/core/src/main/resources/messages/TodosaurusCore.properties
+++ b/core/src/main/resources/messages/TodosaurusCore.properties
@@ -30,6 +30,8 @@ settings.patterns.title=Patterns
 
 wizard.rememberMyChoice.title=Remember my choice
 wizard.chooseAnotherTracker.title=Choose another tracker
+wizard.issueTrackerDetails.title=Will be reported to {0}
+wizard.issueTrackerDetailsWithOwner.title=Will be reported to {0} as {1}
 
 wizard.steps.chooseIssueTracker.issueTracker.title=Choose an issue tracker:
 wizard.steps.chooseIssueTracker.issueTracker.description=This list contains issue trackers supported by Todosaurus


### PR DESCRIPTION
Closes #173 

Hey guys!

This PR improves the wizard UI by showing the selected issue tracker ID and (if available) repository owner.

Screenshot:
![image](https://github.com/user-attachments/assets/7df22295-9c3f-4d12-aa6a-2b0f6f13d30b)

I'm quite new to IntelliJ plugin development, Kotlin, and Swing — so if anything looks off or could be improved, I’d really appreciate your feedback. Open to any suggestions!