### PR TITLE
Handle GitLab error response properly while searching an issue [#172]

### DIFF
--- a/gitLab/src/main/kotlin/me/fornever/todosaurus/gitLab/GitLabClient.kt
+++ b/gitLab/src/main/kotlin/me/fornever/todosaurus/gitLab/GitLabClient.kt
@@ -84,7 +84,7 @@ class GitLabClient(
 
         val responseHandler = InflatedStreamReadingBodyHandler { responseInfo, bodyStream ->
             InputStreamReader(bodyStream, Charsets.UTF_8).use { reader ->
-                when (responseInfo.statusCode()) {
+                when (val code = responseInfo.statusCode()) {
                     200 -> {
                         GitLabRestJsonDataDeSerializer.fromJson(reader, GitLabIssue::class.java)
                     }
@@ -98,7 +98,7 @@ class GitLabClient(
                             GitLabRestJsonDataDeSerializer.fromJson(reader, GitLabErrorResponse::class.java)
                         val errorMessage = errorResponse?.message
                             ?: errorResponse?.error
-                            ?: "Unknown error occurred with ${responseInfo.statusCode()} HTTP status code."
+                            ?: "Unknown error occurred with $code HTTP status code."
                         error(errorMessage)
                     }
                 }

--- a/gitLab/src/main/kotlin/me/fornever/todosaurus/gitLab/api/GitLabErrorResponse.kt
+++ b/gitLab/src/main/kotlin/me/fornever/todosaurus/gitLab/api/GitLabErrorResponse.kt
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Todosaurus contributors <https://github.com/ForNeVeR/Todosaurus>
+//
+// SPDX-License-Identifier: MIT
+package me.fornever.todosaurus.gitLab.api
+
+data class GitLabErrorResponse(
+    val message: String?,
+    val error: String?
+)


### PR DESCRIPTION
Closes #172 

Screenshot reference:
![Screenshot from 2025-03-27 12-02-11](https://github.com/user-attachments/assets/cb83dca6-a3f7-4117-9e68-d59ecd7389ae)
