### PR TITLE
Fix: title extraction truncates when comment body contains //

### DIFF
--- a/intellij/core/src/main/kotlin/me/fornever/todosaurus/core/issues/ToDoItem.kt
+++ b/intellij/core/src/main/kotlin/me/fornever/todosaurus/core/issues/ToDoItem.kt
@@ -107,8 +107,8 @@ sealed class ToDoItem(val text: String, protected val todosaurusSettings: Todosa
     }
 
     var title: String = text
-        .substringAfter("//")
-        .substringAfter("/*")
+        .removePrefix("//")
+        .removePrefix("/*")
         .substringBefore("*/")
         .substringBefore("\n")
         .replace(newItemPattern, "")

--- a/intellij/core/src/test/kotlin/me/fornever/todosaurus/core/toDoItemTests/TitleTests.kt
+++ b/intellij/core/src/test/kotlin/me/fornever/todosaurus/core/toDoItemTests/TitleTests.kt
@@ -27,7 +27,8 @@ class TitleTests {
             Arguments.of("Todo:Text", "Text"),
             Arguments.of("TODO    Text", "Text"),
             Arguments.of("TODO\nText", ""),
-            Arguments.of("/* TODO: Text", "Text")
+            Arguments.of("/* TODO: Text", "Text"),
+            Arguments.of("// TODO: Restore after https://example.com is fixed.", "Restore after https://example.com is fixed.")
         )
         // IgnoreTODO-End
     }


### PR DESCRIPTION
Fixes #261.

The title extraction chain in `ToDoItem.kt` calls `substringAfter("//")` / `substringAfter("/*")` to strip comment markers. These match the first occurrence anywhere in the string, so when a comment body contains a URL like `https://...`, the `//` inside the URL is matched and everything before it is discarded.

Replaced both calls with `removePrefix`, which only strips the literal prefix when it is actually at the start. All existing test cases continue to pass, and a regression test covering the reported scenario is added.