### PR TITLE
fix(core): wrap UrlReplacements.update document access in ReadAction (#305)

### DIFF
--- a/intellij/core/src/main/kotlin/me/fornever/todosaurus/core/issues/UrlReplacements.kt
+++ b/intellij/core/src/main/kotlin/me/fornever/todosaurus/core/issues/UrlReplacements.kt
@@ -4,6 +4,8 @@
 
 package me.fornever.todosaurus.core.issues
 
+import com.intellij.openapi.application.ReadAction
+
 data class UrlReplacement(
     val positionInDescription: IntRange,
     val linesBefore: Int,
@@ -49,41 +51,50 @@ class UrlReplacements(private val toDoItem: ToDoItem.New) {
         if (latestDescription.isEmpty())
             return
 
-        val document = toDoItem.toDoRange.document
-        val startTextOffset = toDoItem.toDoRange.startOffset
-        val endTextOffset = toDoItem.toDoRange.endOffset
+        // RangeMarkerImpl.getDocument() and the Document line accessors below
+        // assert read access on every call. setDescription() is invoked from
+        // the Swing DocumentAdapter on the EDT, where read access is not
+        // guaranteed, so a plain `toDoItem.toDoRange.document` throws
+        // RuntimeExceptionWithAttachments and crashes the wizard step
+        // (issue #305). Wrap the document-touching block in ReadAction.compute
+        // — the result is just data, so no follow-up write is needed.
+        offsets = ReadAction.compute<List<UrlReplacement>, RuntimeException> {
+            val document = toDoItem.toDoRange.document
+            val startTextOffset = toDoItem.toDoRange.startOffset
+            val endTextOffset = toDoItem.toDoRange.endOffset
 
-        offsets = urlReplacementPattern
-            .findAll(latestDescription)
-            .map { match ->
-                val firstToken = match.groups[1]?.value ?: match.groups[3]?.value ?: match.groups[5]?.value ?: match.groups[6]?.value
-                val secondToken = match.groups[2]?.value ?: match.groups[4]?.value
+            urlReplacementPattern
+                .findAll(latestDescription)
+                .map { match ->
+                    val firstToken = match.groups[1]?.value ?: match.groups[3]?.value ?: match.groups[5]?.value ?: match.groups[6]?.value
+                    val secondToken = match.groups[2]?.value ?: match.groups[4]?.value
 
-                var linesBefore = 0
-                var linesAfter = 0
+                    var linesBefore = 0
+                    var linesAfter = 0
 
-                fun parse(token: String) {
-                    val linesCount = token.toInt()
+                    fun parse(token: String) {
+                        val linesCount = token.toInt()
 
-                    when {
-                        linesCount < 0 -> linesBefore = linesCount
-                        else -> linesAfter = linesCount
+                        when {
+                            linesCount < 0 -> linesBefore = linesCount
+                            else -> linesAfter = linesCount
+                        }
                     }
+
+                    if (firstToken != null)
+                        parse(firstToken)
+
+                    if (secondToken != null)
+                        parse(secondToken)
+
+                    val startLineNumber = (document.getLineNumber(startTextOffset) + linesBefore + 1).coerceAtLeast(1)
+                    val startLineOffset = document.getLineStartOffset(startLineNumber - 1)
+                    val endLineNumber = (document.getLineNumber(endTextOffset) + linesAfter + 1).coerceAtMost(document.lineCount)
+                    val endLineOffset = document.getLineEndOffset(endLineNumber - 1)
+
+                    UrlReplacement(IntRange(match.range.first, match.range.last + 1), linesBefore, linesAfter, startLineOffset, endLineOffset, startLineNumber, endLineNumber)
                 }
-
-                if (firstToken != null)
-                    parse(firstToken)
-
-                if (secondToken != null)
-                    parse(secondToken)
-
-                val startLineNumber = (document.getLineNumber(startTextOffset) + linesBefore + 1).coerceAtLeast(1)
-                val startLineOffset = document.getLineStartOffset(startLineNumber - 1)
-                val endLineNumber = (document.getLineNumber(endTextOffset) + linesAfter + 1).coerceAtMost(document.lineCount)
-                val endLineOffset = document.getLineEndOffset(endLineNumber - 1)
-
-                UrlReplacement(IntRange(match.range.first, match.range.last + 1), linesBefore, linesAfter, startLineOffset, endLineOffset, startLineNumber, endLineNumber)
-            }
-            .toList()
+                .toList()
+        }
     }
 }

--- a/intellij/core/src/main/kotlin/me/fornever/todosaurus/core/issues/UrlReplacements.kt
+++ b/intellij/core/src/main/kotlin/me/fornever/todosaurus/core/issues/UrlReplacements.kt
@@ -57,7 +57,7 @@ class UrlReplacements(private val toDoItem: ToDoItem.New) {
         // guaranteed, so a plain `toDoItem.toDoRange.document` throws
         // RuntimeExceptionWithAttachments and crashes the wizard step
         // (issue #305). Wrap the document-touching block in ReadAction.compute
-        // — the result is just data, so no follow-up write is needed.
+        //, the result is just data, so no follow-up write is needed.
         offsets = ReadAction.compute<List<UrlReplacement>, RuntimeException> {
             val document = toDoItem.toDoRange.document
             val startTextOffset = toDoItem.toDoRange.startOffset


### PR DESCRIPTION
Closes #305.

## Summary
The Swing \`DocumentAdapter\` on the EDT calls \`ToDoItem.setDescription\`, which invokes \`UrlReplacements.update\`, which in turn dereferences \`toDoItem.toDoRange.document\` and the line\\* accessors:
```kotlin
val document = toDoItem.toDoRange.document
val startLineNumber = document.getLineNumber(startTextOffset) + ...
val startLineOffset = document.getLineStartOffset(startLineNumber - 1)
```
\`RangeMarkerImpl.getDocument\` and the document line accessors all call \`ThreadingAssertions.softAssertReadAccess\`. The EDT does not hold read access by default, so a single keystroke in the wizard description field throws \`RuntimeExceptionWithAttachments\` and crashes the step (the exact stack trace in the issue).

## Fix
Wrap the document-touching block in \`ReadAction.compute\`. The block returns the freshly built \`List<UrlReplacement>\` (pure data, no follow-up write is needed), and the existing early-returns for empty / unchanged descriptions stay *outside* the \`ReadAction\` so we don't enter it on every redundant keystroke.

```kotlin
offsets = ReadAction.compute<List<UrlReplacement>, RuntimeException> {
    val document = toDoItem.toDoRange.document
    ...
    urlReplacementPattern.findAll(latestDescription).map { ... }.toList()
}
```

## Test plan
- The repo's existing core test suite does not exercise \`UrlReplacements\` (there are no tests under \`core/src/test\` that touch this class), so the fix lands without a new unit test. The change is minimal: one targeted wrapper + one new \`com.intellij.openapi.application.ReadAction\` import.
- Verified the file still compiles by inspecting the Kotlin syntax (the original block is reused verbatim inside the lambda, with the early returns and the offsets assignment moved to use the \`ReadAction.compute\` return value).
- Per the IntelliJ platform contract, \`ReadAction.compute\` is safe on the EDT, it grabs read access for the duration of the lambda and releases it on exit.

## Notes
- The follow-up reading the issue may want to do is audit other places in \`me.fornever.todosaurus.core\` that touch \`Document\` or \`RangeMarker\` from EDT-driven code paths; this fix only addresses the call site flagged in the stack trace.