### PR TITLE
Fix: ignore git submodule entries

### DIFF
--- a/cli/Cli/GitFileProvider.fs
+++ b/cli/Cli/GitFileProvider.fs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Friedrich von Never <friedrich@fornever.me>
+// SPDX-FileCopyrightText: 2026 Todosaurus contributors <https://github.com/ForNeVeR/Todosaurus>
 //
 // SPDX-License-Identifier: MIT
 
@@ -9,23 +9,25 @@ open System.Collections.Generic
 open System.Threading.Tasks
 open TruePath
 
-let private gitlinkMode = "160000"
+/// https://git-scm.com/book/en/v2/Git-Tools-Submodules
+let private submoduleMode = "160000"
 
 let private splitNullSeparated(value: string): string array =
     value.Split('\000', StringSplitOptions.RemoveEmptyEntries)
 
-let private tryGetPathFromCachedLsFilesEntry(entry: string): string option =
+/// Format: "<mode> <hash> <stage>\t<relative-path>"
+let private getPathFromCachedLsFilesEntry(entry: string): string option =
     match entry.IndexOf('\t') with
-    | -1 -> Some entry
+    | -1 -> failwithf $"Cannot parse ls-files output line: \"%s{entry}\"."
     | metadataSeparator ->
         let metadata = entry.Substring(0, metadataSeparator)
         let relativePath = entry.Substring(metadataSeparator + 1)
         let metadataParts = metadata.Split(' ', StringSplitOptions.RemoveEmptyEntries)
 
         match metadataParts with
-        | [| mode; _objectId; _stage |] when mode = gitlinkMode -> None
+        | [| mode; _objectId; _stage |] when mode = submoduleMode -> None // ignore submodule entries
         | [| _mode; _objectId; _stage |] -> Some relativePath
-        | _ -> Some entry
+        | _ -> failwithf $"Cannot parse ls-files output line: \"%s{entry}\"."
 
 let IsGitAvailable(): Task<bool> =
     task {
@@ -39,13 +41,17 @@ let IsGitAvailable(): Task<bool> =
 
 let ListFiles(directory: AbsolutePath, includeUntracked: bool): Task<IReadOnlyList<AbsolutePath>> =
     task {
+        // Ideally, we would collect all the info with one call to git ls-files, but unfortunately, it's not possible:
+        // the output formats for most common call (--stage --others) differs between different kinds of entries, and
+        // it's impossible to know in advance if we observe a valid staged file entry, or an unstaged file with its name
+        // including tabs and spaces, so that it looks like a valid staged entry.
         let! cachedResult =
             Shell.RunProcess(directory, LocalPath "git", [ "ls-files"; "-z"; "--stage"; "--cached" ])
 
         let cachedFiles =
             cachedResult.StandardOutput
             |> splitNullSeparated
-            |> Array.choose tryGetPathFromCachedLsFilesEntry
+            |> Array.choose getPathFromCachedLsFilesEntry
 
         let! untrackedFiles =
             if includeUntracked then

--- a/cli/Cli/GitFileProvider.fs
+++ b/cli/Cli/GitFileProvider.fs
@@ -9,6 +9,24 @@ open System.Collections.Generic
 open System.Threading.Tasks
 open TruePath
 
+let private gitlinkMode = "160000"
+
+let private splitNullSeparated(value: string): string array =
+    value.Split('\000', StringSplitOptions.RemoveEmptyEntries)
+
+let private tryGetPathFromCachedLsFilesEntry(entry: string): string option =
+    match entry.IndexOf('\t') with
+    | -1 -> Some entry
+    | metadataSeparator ->
+        let metadata = entry.Substring(0, metadataSeparator)
+        let relativePath = entry.Substring(metadataSeparator + 1)
+        let metadataParts = metadata.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+
+        match metadataParts with
+        | [| mode; _objectId; _stage |] when mode = gitlinkMode -> None
+        | [| _mode; _objectId; _stage |] -> Some relativePath
+        | _ -> Some entry
+
 let IsGitAvailable(): Task<bool> =
     task {
         try
@@ -21,16 +39,29 @@ let IsGitAvailable(): Task<bool> =
 
 let ListFiles(directory: AbsolutePath, includeUntracked: bool): Task<IReadOnlyList<AbsolutePath>> =
     task {
-        let args =
-            if includeUntracked then
-                [ "ls-files"; "-z"; "--cached"; "--others"; "--exclude-standard" ]
-            else
-                [ "ls-files"; "-z"; "--cached" ]
+        let! cachedResult =
+            Shell.RunProcess(directory, LocalPath "git", [ "ls-files"; "-z"; "--stage"; "--cached" ])
 
-        let! result = Shell.RunProcess(directory, LocalPath "git", args)
+        let cachedFiles =
+            cachedResult.StandardOutput
+            |> splitNullSeparated
+            |> Array.choose tryGetPathFromCachedLsFilesEntry
+
+        let! untrackedFiles =
+            if includeUntracked then
+                task {
+                    let! result =
+                        Shell.RunProcess(directory, LocalPath "git", [ "ls-files"; "-z"; "--others"; "--exclude-standard" ])
+
+                    return splitNullSeparated result.StandardOutput
+                }
+            else
+                task {
+                    return [||]
+                }
 
         return
-            result.StandardOutput.Split('\000', StringSplitOptions.RemoveEmptyEntries)
+            Array.append cachedFiles untrackedFiles
             |> Array.map(fun relativePath -> directory / relativePath)
             :> IReadOnlyList<_>
     }

--- a/cli/Tests/FilesCommandTests.fs
+++ b/cli/Tests/FilesCommandTests.fs
@@ -17,6 +17,13 @@ let private runGit (workingDirectory: AbsolutePath) (args: string seq): Task =
         return ()
     }
 
+let private configureGitUser (workingDirectory: AbsolutePath): Task =
+    task {
+        do! runGit workingDirectory [ "config"; "user.email"; "test@test.com" ]
+        do! runGit workingDirectory [ "config"; "user.name"; "Test" ]
+        do! runGit workingDirectory [ "config"; "commit.gpgSign"; "false" ]
+    }
+
 let private assertNoGitDir(dir: AbsolutePath) =
     let gitPath = (dir / ".git")
 
@@ -61,8 +68,7 @@ let ``Git repo lists tracked and untracked-not-ignored text files, excludes bina
     WithTempDir(fun tempDir -> task {
         assertNoGitDir tempDir
         do! runGit tempDir [ "init" ]
-        do! runGit tempDir [ "config"; "user.email"; "test@test.com" ]
-        do! runGit tempDir [ "config"; "user.name"; "Test" ]
+        do! configureGitUser tempDir
 
         // Tracked files (should appear):
         do! (tempDir / "tracked.txt").WriteAllTextAsync "tracked"
@@ -98,8 +104,7 @@ let ``CI mode excludes untracked files from Git repo scan``(): Task =
     WithTempDir(fun tempDir -> task {
         assertNoGitDir tempDir
         do! runGit tempDir [ "init" ]
-        do! runGit tempDir [ "config"; "user.email"; "test@test.com" ]
-        do! runGit tempDir [ "config"; "user.name"; "Test" ]
+        do! configureGitUser tempDir
 
         // Tracked file:
         do! (tempDir / "tracked.txt").WriteAllTextAsync "tracked"
@@ -118,6 +123,34 @@ let ``CI mode excludes untracked files from Git repo scan``(): Task =
             Assert.DoesNotContain("untracked.txt", names)
         finally
             Env.SetIsCiOverride None
+    })
+
+[<Fact>]
+let ``Git repo ignores submodule gitlinks``(): Task =
+    WithTempDir(fun tempDir -> task {
+        assertNoGitDir tempDir
+        do! runGit tempDir [ "init" ]
+        do! configureGitUser tempDir
+
+        do! (tempDir / "tracked.txt").WriteAllTextAsync "tracked"
+        do! runGit tempDir [ "add"; "tracked.txt" ]
+
+        let submodulePath = "wwwroot/talks/demo"
+        do! runGit tempDir [
+            "update-index"
+            "--add"
+            "--cacheinfo"
+            $"160000,0123456789012345678901234567890123456789,%s{submodulePath}"
+        ]
+        do! runGit tempDir [ "commit"; "-m"; "initial" ]
+
+        let! result = RunWithLoggerCollector(fun ctx -> task {
+            let! files = FilesCommand.ListEligibleFiles(ctx, tempDir)
+            let names = files |> Seq.map _.Value
+            Assert.Contains("tracked.txt", names)
+            Assert.DoesNotContain(submodulePath, names)
+        })
+        Assert.Empty result.Warnings
     })
 
 [<Fact>]

--- a/cli/Tests/FilesCommandTests.fs
+++ b/cli/Tests/FilesCommandTests.fs
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2026 Friedrich von Never <friedrich@fornever.me>
+// SPDX-FileCopyrightText: 2026 Todosaurus contributors <https://github.com/ForNeVeR/Todosaurus>
 //
 // SPDX-License-Identifier: MIT
 
 module Todosaurus.Tests.FilesCommandTests
 
+open System.Collections.Generic
 open System.Threading.Tasks
 open Todosaurus.Cli
 open Todosaurus.Tests.TestFramework
@@ -126,7 +127,7 @@ let ``CI mode excludes untracked files from Git repo scan``(): Task =
     })
 
 [<Fact>]
-let ``Git repo ignores submodule gitlinks``(): Task =
+let ``Git repo ignores submodule entries``(): Task =
     WithTempDir(fun tempDir -> task {
         assertNoGitDir tempDir
         do! runGit tempDir [ "init" ]
@@ -146,9 +147,9 @@ let ``Git repo ignores submodule gitlinks``(): Task =
 
         let! result = RunWithLoggerCollector(fun ctx -> task {
             let! files = FilesCommand.ListEligibleFiles(ctx, tempDir)
-            let names = files |> Seq.map _.Value
-            Assert.Contains("tracked.txt", names)
-            Assert.DoesNotContain(submodulePath, names)
+            let files = HashSet files
+            Assert.Contains(LocalPath "tracked.txt", files)
+            Assert.DoesNotContain(LocalPath submodulePath, files)
         })
         Assert.Empty result.Warnings
     })


### PR DESCRIPTION
## Summary

Fixes #312.

The CLI Git file provider now reads cached entries through `git ls-files --stage --cached` and filters out entries with mode `160000`, which are Git submodule/gitlink entries rather than readable files. Untracked files are still listed separately with the existing `--others --exclude-standard` path, so local scans continue to include untracked non-ignored text files without parsing staged metadata into those path names.

I also added a focused regression test that creates the same Git index shape as a committed submodule via `git update-index --cacheinfo 160000,...`, then verifies the scanner still returns a normal tracked file while ignoring the gitlink path without warnings.

Verification run locally:

- `/tmp/dotnet-todosaurus/dotnet test cli/Tests/Tests.fsproj --filter "FullyQualifiedName~Git repo ignores submodule gitlinks" --no-restore`
- `git diff --check`
